### PR TITLE
apply bootstrap 5 changes to template overrides

### DIFF
--- a/templates/navigation-bar.twig
+++ b/templates/navigation-bar.twig
@@ -8,8 +8,8 @@
 	  {% set search_label = __( 'Search', 'planet4-master-theme' ) %}
     <button
         class="btn btn-navbar-toggle navbar-dropdown-toggle"
-        data-toggle="open"
-        data-target="#navbar-dropdown"
+        data-bs-toggle="open"
+        data-bs-target="#navbar-dropdown"
         aria-expanded="false"
 				aria-label="{{ toggle_label }}"
     >
@@ -27,8 +27,8 @@
         </button>
         <button
             class="country-dropdown-toggle"
-            data-toggle="open"
-            data-target="#country-list"
+            data-bs-toggle="open"
+            data-bs-target="#country-list"
             aria-expanded="false"
 			aria-label="{{ data_nav_bar.country_dropdown_toggle }}"
         >
@@ -66,8 +66,8 @@
 	</ul>
     <button
         class="navbar-search-toggle"
-        data-toggle="open"
-        data-target="#search_form"
+        data-bs-toggle="open"
+        data-bs-target="#search_form"
         aria-expanded="false"
 		aria-label="{{ data_nav_bar.navbar_search_toggle }}"
     >


### PR DESCRIPTION
For now this involves just applying the same changes we did in master theme to the overridden template. There is also a PR for master theme to explicitly define the loading order of bootstrap and the theme CSS. For some reason this changed, causing our reboot to not work. https://github.com/greenpeace/planet4-master-theme/pull/1342